### PR TITLE
Add React web chat app

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,3 +28,15 @@ python code_assistant.py --path ./my_project enhance file.py
 # Ask the model to fix bugs in file.py using the "mistral" model
 python code_assistant.py --path ./my_project --model mistral fix file.py
 ```
+
+## Web Chat Application
+
+A browser-based chat interface is located in `web-app/`. It uses React to send messages directly to your local Ollama instance.
+
+To try it out, start a simple static server from the repository root:
+
+```bash
+npx serve web-app
+```
+
+Open `http://localhost:3000` (or the port printed by `serve`) and begin chatting. The app expects Ollama to be running on `http://localhost:11434` and uses the `llama3` model by default.

--- a/web-app/app.jsx
+++ b/web-app/app.jsx
@@ -1,0 +1,57 @@
+const API_URL = 'http://localhost:11434/api/generate';
+const MODEL = 'llama3';
+
+function ChatApp() {
+  const [messages, setMessages] = React.useState([]);
+  const [input, setInput] = React.useState('');
+  const inputRef = React.useRef(null);
+
+  const sendMessage = async () => {
+    const text = input.trim();
+    if (!text) return;
+    const userMsg = { sender: 'user', text };
+    setMessages((msgs) => [...msgs, userMsg]);
+    setInput('');
+    try {
+      const res = await fetch(API_URL, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ model: MODEL, prompt: text }),
+      });
+      const data = await res.json();
+      const botMsg = { sender: 'bot', text: data.response || 'No response' };
+      setMessages((msgs) => [...msgs, botMsg]);
+    } catch (err) {
+      setMessages((msgs) => [
+        ...msgs,
+        { sender: 'bot', text: 'Error contacting Ollama: ' + err },
+      ]);
+    }
+    inputRef.current.focus();
+  };
+
+  return (
+    <div id="chat">
+      <div className="messages">
+        {messages.map((m, i) => (
+          <div key={i} className={`message ${m.sender}`}>{
+            m.sender === 'user' ? 'You: ' : 'Bot: '
+          }{m.text}</div>
+        ))}
+      </div>
+      <input
+        type="text"
+        value={input}
+        ref={inputRef}
+        placeholder="Ask something..."
+        onChange={(e) => setInput(e.target.value)}
+        onKeyDown={(e) => {
+          if (e.key === 'Enter') sendMessage();
+        }}
+      />
+      <button onClick={sendMessage}>Send</button>
+    </div>
+  );
+}
+
+ReactDOM.render(<ChatApp />, document.getElementById('root'));

--- a/web-app/index.html
+++ b/web-app/index.html
@@ -1,0 +1,16 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Ollama React Chat</title>
+    <link rel="stylesheet" href="style.css" />
+    <script src="https://unpkg.com/react@17/umd/react.development.js" crossorigin></script>
+    <script src="https://unpkg.com/react-dom@17/umd/react-dom.development.js" crossorigin></script>
+    <script src="https://unpkg.com/babel-standalone@6/babel.min.js"></script>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="text/babel" src="app.jsx"></script>
+  </body>
+</html>

--- a/web-app/style.css
+++ b/web-app/style.css
@@ -1,0 +1,40 @@
+body {
+  font-family: Arial, sans-serif;
+  background: #f8f8f8;
+  padding: 40px;
+}
+
+#chat {
+  width: 600px;
+  margin: auto;
+}
+
+.messages {
+  border: 1px solid #ccc;
+  background: #fff;
+  height: 400px;
+  overflow-y: scroll;
+  padding: 10px;
+}
+
+input[type="text"] {
+  width: 80%;
+  padding: 10px;
+  margin-top: 10px;
+}
+
+button {
+  padding: 10px;
+}
+
+.message {
+  margin-bottom: 10px;
+}
+
+.user {
+  font-weight: bold;
+}
+
+.bot {
+  color: green;
+}


### PR DESCRIPTION
## Summary
- swap Python-based `web_chat.py` for a static React implementation
- provide new `web-app/` directory with React, HTML and CSS files
- document how to launch the chat using `npx serve`

## Testing
- `python -m py_compile code_assistant.py`
- `node --version`


------
https://chatgpt.com/codex/tasks/task_e_6841acc5be44832ca40e7eaa38d0afc6